### PR TITLE
Feature/fix md link

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 2,
-  "name": "my-trello-extension",
-  "description": "My Trello Chrome Extension",
-  "version": "0.1.0",
+  "name": "strobo-trello-extension",
+  "description": "Extension for Trello by Strobo",
+  "version": "1.0.0",
   "content_scripts": [
     {
       "css": [ "mytrello.css" ],

--- a/mytrello.js
+++ b/mytrello.js
@@ -33,8 +33,8 @@
 
   function init() {
     var ob = new MutationObserver(function(records){
-      for (var i = 0; i < records.length; i++) {
-        var record = records[i];
+      for (var i = 0; i < records.length; i++) {        
+        var record = records[i];        
         if(record.target.id === 'content') {
           addFitButton();
           addWiderButton();
@@ -103,7 +103,7 @@
 
     card.insertBefore(buttonElement, closetElement);
 
-    buttonElement.addEventListener('click', function(e) {
+    buttonElement.addEventListener('click', function(e) {    
       e.stopPropagation();
       var copyFrom = document.createElement("textarea");
       var markdownText = [
@@ -112,7 +112,7 @@
           ' ',
           title.lastChild.textContent,
         '](',
-          title.href,
+          generateUrlForMDLink(card),
         ')'
       ].join('');
       copyFrom.textContent = markdownText;
@@ -121,6 +121,14 @@
       document.execCommand('copy');
       document.body.removeChild(copyFrom)
     });
+  }
+  
+  // Markdownリンクの末尾にページのtitleが含まれて
+  // しまいリンクが冗長になる問題を解決
+  function generateUrlForMDLink(card) {
+    var urlComp = card.href.split("/");
+    urlComp.pop();
+    return urlComp.join("/");
   }
 
   function showExtraCardUI() {

--- a/mytrello.js
+++ b/mytrello.js
@@ -104,7 +104,7 @@
     card.insertBefore(buttonElement, closetElement);
 
     buttonElement.addEventListener('click', function(e) {    
-      e.stopPropagation();
+      // e.stopPropagation();
       var copyFrom = document.createElement("textarea");
       var markdownText = [
         '[',

--- a/mytrello.js
+++ b/mytrello.js
@@ -58,7 +58,7 @@
     });
 
     ob.observe(document.body, {
-      attributes: true,
+      attributes: false,
       childList: true,
       subtree: true
     });

--- a/mytrello.js
+++ b/mytrello.js
@@ -58,7 +58,7 @@
     });
 
     ob.observe(document.body, {
-      attributes: false,
+      attributes: true,
       childList: true,
       subtree: true
     });


### PR DESCRIPTION
- バージョン情報とアプリ名の更新
- マークダウンボタンについて
  - Trelloの仕様変更によりカードのリンクにpage titleが含まれ冗長になるので、生成されるmarkdownリンクにpage titleが含まれないように改善
  - mark downリンク生成ボタンが、カードを移動しない限り表示されない問題への対応